### PR TITLE
Delete has_moss.json

### DIFF
--- a/forge/src/main/resources/data/grounded/forge/biome_modifier/has_moss.json
+++ b/forge/src/main/resources/data/grounded/forge/biome_modifier/has_moss.json
@@ -1,8 +1,0 @@
-{
-  "type": "forge:add_features",
-  "biomes": "#grounded:has_moss",
-  "features": [
-    "grounded:moss_patch"
-  ],
-  "step": "vegetal_decoration"
-}


### PR DESCRIPTION
unconfigured forge biome modifier that crashes the game at world creation.